### PR TITLE
Use new diffcalc fields

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,7 +63,10 @@ const AppWithContext = () => {
 
     return (
         <Switch>
-            <Route exact path="/leaderboards/:leaderboardType(global|community)/:gamemode(osu|taiko|catch|mania)/:leaderboardId(\d+)/dashboard">
+            <Route
+                exact
+                path="/leaderboards/:leaderboardType(global|community)/:gamemode(osu|taiko|catch|mania)/:leaderboardId(\d+)/dashboard"
+            >
                 <LeaderboardDashboard />
             </Route>
             <Route>

--- a/src/Osuchan/Leaderboards/Leaderboard/MemberModal.tsx
+++ b/src/Osuchan/Leaderboards/Leaderboard/MemberModal.tsx
@@ -99,89 +99,92 @@ const MemberInfo = observer(() => {
                 )}
             </Helmet>
 
-            {loadingMembershipStatus === ResourceStatus.Loaded && membership && (
-                <>
-                    <UserInfo>
-                        <Avatar
-                            src={`https://a.ppy.sh/${membership.osuUserId}`}
-                        />
-                        <UserInfoContainer>
-                            <UserInfoRow>
-                                <Username>
-                                    {membership.osuUser!.username}
-                                </Username>
-                            </UserInfoRow>
-                            <UserInfoRow>
-                                <Flag
-                                    countryCode={membership.osuUser!.country}
-                                    showFullName
-                                />
-                            </UserInfoRow>
-                            <UserInfoRow>
-                                <ScoreCount>
-                                    {membership.scoreCount} scores
-                                </ScoreCount>
-                            </UserInfoRow>
-                        </UserInfoContainer>
-                        <UserInfoContainer>
-                            <UserInfoRow>
-                                <Rank>
-                                    #{membership.rank.toLocaleString("en")}
-                                </Rank>
-                            </UserInfoRow>
-                            <UserInfoRow>
-                                <Performance>
-                                    <NumberFormat
-                                        value={membership.pp}
-                                        decimalPlaces={0}
+            {loadingMembershipStatus === ResourceStatus.Loaded &&
+                membership && (
+                    <>
+                        <UserInfo>
+                            <Avatar
+                                src={`https://a.ppy.sh/${membership.osuUserId}`}
+                            />
+                            <UserInfoContainer>
+                                <UserInfoRow>
+                                    <Username>
+                                        {membership.osuUser!.username}
+                                    </Username>
+                                </UserInfoRow>
+                                <UserInfoRow>
+                                    <Flag
+                                        countryCode={
+                                            membership.osuUser!.country
+                                        }
+                                        showFullName
                                     />
-                                    pp
-                                </Performance>
-                            </UserInfoRow>
-                        </UserInfoContainer>
-                    </UserInfo>
+                                </UserInfoRow>
+                                <UserInfoRow>
+                                    <ScoreCount>
+                                        {membership.scoreCount} scores
+                                    </ScoreCount>
+                                </UserInfoRow>
+                            </UserInfoContainer>
+                            <UserInfoContainer>
+                                <UserInfoRow>
+                                    <Rank>
+                                        #{membership.rank.toLocaleString("en")}
+                                    </Rank>
+                                </UserInfoRow>
+                                <UserInfoRow>
+                                    <Performance>
+                                        <NumberFormat
+                                            value={membership.pp}
+                                            decimalPlaces={0}
+                                        />
+                                        pp
+                                    </Performance>
+                                </UserInfoRow>
+                            </UserInfoContainer>
+                        </UserInfo>
 
-                    {isAuthenticated &&
-                        leaderboard!.ownerId === user!.osuUserId &&
-                        membership?.osuUserId !== user!.osuUserId && (
-                            <>
-                                <Divider spacingScale={5} />
-                                <Button
-                                    negative
-                                    isLoading={detailStore.isKickingMember}
-                                    action={() => detailStore.kickMember()}
-                                    confirmationMessage="Are you sure you want to kick this member from the leaderboard?"
-                                >
-                                    Kick Member
-                                </Button>
-                            </>
+                        {isAuthenticated &&
+                            leaderboard!.ownerId === user!.osuUserId &&
+                            membership?.osuUserId !== user!.osuUserId && (
+                                <>
+                                    <Divider spacingScale={5} />
+                                    <Button
+                                        negative
+                                        isLoading={detailStore.isKickingMember}
+                                        action={() => detailStore.kickMember()}
+                                        confirmationMessage="Are you sure you want to kick this member from the leaderboard?"
+                                    >
+                                        Kick Member
+                                    </Button>
+                                </>
+                            )}
+
+                        <Divider spacingScale={5} />
+
+                        {(showAllScores
+                            ? membershipScores
+                            : membershipScores.slice(0, 5)
+                        ).map((score, i) => (
+                            <ScoreRow key={i} score={score} hidePlayerInfo />
+                        ))}
+                        {membershipScores.length <= 5 || showAllScores || (
+                            <Button
+                                type="button"
+                                fullWidth
+                                action={() => setShowAllScores(true)}
+                            >
+                                Show More
+                            </Button>
                         )}
-
-                    <Divider spacingScale={5} />
-
-                    {(showAllScores
-                        ? membershipScores
-                        : membershipScores.slice(0, 5)
-                    ).map((score, i) => (
-                        <ScoreRow key={i} score={score} hidePlayerInfo />
-                    ))}
-                    {membershipScores.length <= 5 || showAllScores || (
-                        <Button
-                            type="button"
-                            fullWidth
-                            action={() => setShowAllScores(true)}
-                        >
-                            Show More
-                        </Button>
-                    )}
-                    {membershipScores.length === 0 && (
-                        <p>
-                            This member has no eligible scores for this
-                            leaderboard yet...
-                        </p>
-                    )}
-                </>
-            )}
+                        {membershipScores.length === 0 && (
+                            <p>
+                                This member has no eligible scores for this
+                                leaderboard yet...
+                            </p>
+                        )}
+                    </>
+                )}
             {loadingMembershipStatus === ResourceStatus.Loading && (
                 <LoadingSection />
             )}

--- a/src/components/layout/ScoreModal.tsx
+++ b/src/components/layout/ScoreModal.tsx
@@ -1,15 +1,14 @@
 import styled from "styled-components";
 
-import { Score } from "../../store/models/profiles/types";
-import { BasicModal } from "./BasicModal";
-import { formatScoreResult, formatTime } from "../../utils/formatting";
-import { DataTable, DataCell } from "./DataTable";
-import { ModIcons } from "./ModIcons";
-import { ScoreResult } from "../../store/models/profiles/enums";
-import { BeatmapStatus, Gamemode } from "../../store/models/common/enums";
-import { TimeAgo } from "./TimeAgo";
-import { NumberFormat } from "./NumberFormat";
 import { observer } from "mobx-react-lite";
+import { BeatmapStatus, Gamemode } from "../../store/models/common/enums";
+import { Score } from "../../store/models/profiles/types";
+import { formatScoreResult, formatTime } from "../../utils/formatting";
+import { BasicModal } from "./BasicModal";
+import { DataCell, DataTable } from "./DataTable";
+import { ModIcons } from "./ModIcons";
+import { NumberFormat } from "./NumberFormat";
+import { TimeAgo } from "./TimeAgo";
 
 const BannerImage = styled.img`
     width: 100%;
@@ -91,10 +90,6 @@ const Performance = styled.span`
 
 const Result = styled.span``;
 
-const NochokePerformance = styled.span`
-    color: ${(props) => props.theme.colours.timber};
-`;
-
 export const ScoreModal = observer((props: ScoreModalProps) => {
     const score = props.score;
     const beatmap = score.beatmap!;
@@ -144,33 +139,33 @@ export const ScoreModal = observer((props: ScoreModalProps) => {
                             Gamemode.Catch,
                             Gamemode.Mania,
                         ].includes(score.gamemode) && (
-                            <tr>
-                                <td>
-                                    {score.gamemode === Gamemode.Mania
-                                        ? "Keys"
-                                        : "Circle Size"}
-                                </td>
-                                <DataCell>
-                                    <NumberFormat
-                                        value={score.circleSize}
-                                        decimalPlaces={1}
-                                    />
-                                </DataCell>
-                            </tr>
-                        )}
+                                <tr>
+                                    <td>
+                                        {score.gamemode === Gamemode.Mania
+                                            ? "Keys"
+                                            : "Circle Size"}
+                                    </td>
+                                    <DataCell>
+                                        <NumberFormat
+                                            value={score.circleSize}
+                                            decimalPlaces={1}
+                                        />
+                                    </DataCell>
+                                </tr>
+                            )}
                         {[Gamemode.Standard, Gamemode.Catch].includes(
                             score.gamemode
                         ) && (
-                            <tr>
-                                <td>Approach Rate</td>
-                                <DataCell>
-                                    <NumberFormat
-                                        value={score.approachRate}
-                                        decimalPlaces={1}
-                                    />
-                                </DataCell>
-                            </tr>
-                        )}
+                                <tr>
+                                    <td>Approach Rate</td>
+                                    <DataCell>
+                                        <NumberFormat
+                                            value={score.approachRate}
+                                            decimalPlaces={1}
+                                        />
+                                    </DataCell>
+                                </tr>
+                            )}
                         <tr>
                             <td>Overall Difficulty</td>
                             <DataCell>
@@ -233,16 +228,6 @@ export const ScoreModal = observer((props: ScoreModalProps) => {
                         pp
                     </Performance>
                     <Result>{formatScoreResult(score.result)}</Result>
-                    {Boolean(score.result & ScoreResult.Choke) && (
-                        <NochokePerformance>
-                            No-choke{" "}
-                            <NumberFormat
-                                value={score.nochokePerformanceTotal}
-                                decimalPlaces={0}
-                            />
-                            pp
-                        </NochokePerformance>
-                    )}
                 </ScoreInfo>
             </InfoContainer>
         </BasicModal>

--- a/src/components/layout/ScoreModal.tsx
+++ b/src/components/layout/ScoreModal.tsx
@@ -176,15 +176,13 @@ export const ScoreModal = observer((props: ScoreModalProps) => {
                             </DataCell>
                         </tr>
                     </BeatmapDataTable>
-                    {score.gamemode === Gamemode.Standard && (
-                        <StarRating>
-                            <NumberFormat
-                                value={score.difficultyTotal}
-                                decimalPlaces={2}
-                            />{" "}
-                            stars
-                        </StarRating>
-                    )}
+                    <StarRating>
+                        <NumberFormat
+                            value={score.difficultyTotal}
+                            decimalPlaces={2}
+                        />{" "}
+                        stars
+                    </StarRating>
                 </BeatmapInfo>
 
                 {/* Score info: date, 300s, 100s, 50s, misses, combo, acc, pp, result */}

--- a/src/pages/LeaderboardDashboard/MemberRankings.tsx
+++ b/src/pages/LeaderboardDashboard/MemberRankings.tsx
@@ -69,7 +69,7 @@ interface RankingRowProps {
 const MemberRankings = observer((props: MemberRankingProps) => (
     <>
         {props.memberships.map((membership, i) => (
-            <MemberRow key={i} rank={i+1} membership={membership} />
+            <MemberRow key={i} rank={i + 1} membership={membership} />
         ))}
     </>
 ));

--- a/src/pages/LeaderboardDashboard/ScoreRankings.tsx
+++ b/src/pages/LeaderboardDashboard/ScoreRankings.tsx
@@ -7,7 +7,9 @@ import { formatScoreResult } from "../../utils/formatting";
 const ScoreRowWrapper = styled(Row)<ScoreRowWrapperProps>`
     padding: 0;
     align-items: unset;
-    background: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)), ${props => `url("https://assets.ppy.sh/beatmaps/${props.beatmapSetId}/covers/cover.jpg")`};
+    background: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)),
+        ${(props) =>
+            `url("https://assets.ppy.sh/beatmaps/${props.beatmapSetId}/covers/cover.jpg")`};
     background-size: cover;
     text-shadow: 0 0 0.5em black;
     font-size: 0.3em;
@@ -110,9 +112,7 @@ export const ScoreRow = observer((props: ScoreRowProps) => {
         <ScoreRowWrapper beatmapSetId={beatmap.setId}>
             <LeftContainer>
                 <PlayerInfo>
-                    <Avatar
-                        src={`https://a.ppy.sh/${userStats.osuUserId}`}
-                    />
+                    <Avatar src={`https://a.ppy.sh/${userStats.osuUserId}`} />
                     <FlagContainer>
                         <Flag countryCode={userStats.osuUser!.country} />
                     </FlagContainer>
@@ -123,9 +123,7 @@ export const ScoreRow = observer((props: ScoreRowProps) => {
                     <Artist>
                         <small>by</small> {beatmap.artist}
                     </Artist>
-                    <DifficultyName>
-                        {beatmap.difficultyName}
-                    </DifficultyName>
+                    <DifficultyName>{beatmap.difficultyName}</DifficultyName>
                 </BeatmapInfo>
             </LeftContainer>
             <ModsContainer>
@@ -166,7 +164,7 @@ interface ScoreRowProps {
 const ScoreRankings = observer((props: ScoreRankingProps) => (
     <>
         {props.scores.map((score, i) => (
-            <ScoreRow key={i} score={score}  />
+            <ScoreRow key={i} score={score} />
         ))}
     </>
 ));

--- a/src/pages/LeaderboardDashboard/index.tsx
+++ b/src/pages/LeaderboardDashboard/index.tsx
@@ -66,10 +66,16 @@ const LeaderboardDashboard = observer(() => {
     const store = useStore();
     const detailStore = store.leaderboardsStore.detailStore;
 
-    const { loadingStatus, leaderboard, rankings, leaderboardScores } = detailStore;
+    const { loadingStatus, leaderboard, rankings, leaderboardScores } =
+        detailStore;
 
     useEffect(() => {
-        detailStore.loadLeaderboard(leaderboardType, gamemode, leaderboardId, true);
+        detailStore.loadLeaderboard(
+            leaderboardType,
+            gamemode,
+            leaderboardId,
+            true
+        );
     }, [detailStore, leaderboardType, gamemode, leaderboardId]);
 
     useEffect(() => {
@@ -77,7 +83,7 @@ const LeaderboardDashboard = observer(() => {
             detailStore.reloadLeaderboard(true);
         }, 5 * 60 * 1000);
         return () => clearInterval(interval);
-      }, [detailStore]);
+    }, [detailStore]);
 
     return (
         <>
@@ -97,7 +103,6 @@ const LeaderboardDashboard = observer(() => {
                 <LoadingPage />
             )}
 
-            
             {detailStore.loadingStatus === ResourceStatus.Error && (
                 <h3>Leaderboard not found!</h3>
             )}

--- a/src/store/leaderboards/detail/store.ts
+++ b/src/store/leaderboards/detail/store.ts
@@ -1,25 +1,24 @@
-import { observable, action, makeAutoObservable, flow } from "mobx";
+import { action, flow, makeAutoObservable, observable } from "mobx";
 
 import history from "../../../history";
 import http from "../../../http";
 import notify from "../../../notifications";
 
+import { formatGamemodeNameShort } from "../../../utils/formatting";
+import { Gamemode } from "../../models/common/enums";
 import {
-    Leaderboard,
-    Membership,
-    Invite,
-} from "../../models/leaderboards/types";
-import { Score } from "../../models/profiles/types";
-import {
+    inviteFromJson,
     leaderboardFromJson,
     membershipFromJson,
-    inviteFromJson,
 } from "../../models/leaderboards/deserialisers";
+import {
+    Invite,
+    Leaderboard,
+    Membership,
+} from "../../models/leaderboards/types";
 import { scoreFromJson } from "../../models/profiles/deserialisers";
-import { unchokeForScoreSet } from "../../../utils/osuchan";
-import { Gamemode } from "../../models/common/enums";
+import { Score } from "../../models/profiles/types";
 import { ResourceStatus } from "../../status";
-import { formatGamemodeNameShort } from "../../../utils/formatting";
 
 export class DetailStore {
     leaderboardType: string | null = null;
@@ -120,10 +119,7 @@ export class DetailStore {
 
             this.leaderboard = leaderboard;
             this.rankings.replace(members);
-            // transform scores into their intended form for abnormal score sets
-            this.leaderboardScores.replace(
-                unchokeForScoreSet(scores, leaderboard.scoreSet)
-            );
+            this.leaderboardScores.replace(scores);
 
             this.loadingStatus = ResourceStatus.Loaded;
         } catch (error: any) {
@@ -377,10 +373,7 @@ export class DetailStore {
             );
 
             this.membership = membership;
-            // transform scores into their intended form for abnormal score sets
-            this.membershipScores.replace(
-                unchokeForScoreSet(scores, this.leaderboard!.scoreSet)
-            );
+            this.membershipScores.replace(scores);
 
             this.loadingMembershipStatus = ResourceStatus.Loaded;
         } catch (error: any) {
@@ -452,10 +445,8 @@ export class DetailStore {
             );
 
             history.push(
-                `/leaderboards/${
-                    this.leaderboardType
-                }/${formatGamemodeNameShort(this.gamemode!)}/${
-                    this.leaderboardId
+                `/leaderboards/${this.leaderboardType
+                }/${formatGamemodeNameShort(this.gamemode!)}/${this.leaderboardId
                 }`
             );
             this.rankings.replace(

--- a/src/store/leaderboards/detail/store.ts
+++ b/src/store/leaderboards/detail/store.ts
@@ -106,11 +106,14 @@ export class DetailStore {
                 (data: any) => membershipFromJson(data)
             );
 
-            const scoresResponse = yield http.get(`${this.resourceUrl}/scores`, {
-                params: {
-                    limit: moreScores ? 100 : 5
+            const scoresResponse = yield http.get(
+                `${this.resourceUrl}/scores`,
+                {
+                    params: {
+                        limit: moreScores ? 100 : 5,
+                    },
                 }
-            });
+            );
             const scores: Score[] = scoresResponse.data.map((data: any) =>
                 scoreFromJson(data)
             );

--- a/src/store/models/profiles/deserialisers.ts
+++ b/src/store/models/profiles/deserialisers.ts
@@ -110,7 +110,6 @@ export function scoreFromJson(data: any): Score {
         overallDifficulty: data["overall_difficulty"],
         result: data["result"],
         performanceTotal: data["performance_total"],
-        nochokePerformanceTotal: data["nochoke_performance_total"],
         difficultyTotal: data["difficulty_total"],
     };
 }

--- a/src/store/models/profiles/deserialisers.ts
+++ b/src/store/models/profiles/deserialisers.ts
@@ -67,7 +67,6 @@ export function beatmapFromJson(data: any): Beatmap {
         submissionDate: new Date(data["submission_date"]),
         approvalDate: new Date(data["approval_date"]),
         lastUpdated: new Date(data["last_updated"]),
-        difficultyTotal: data["difficulty_total"],
     };
 }
 

--- a/src/store/models/profiles/deserialisers.ts
+++ b/src/store/models/profiles/deserialisers.ts
@@ -72,6 +72,7 @@ export function beatmapFromJson(data: any): Beatmap {
 }
 
 export function scoreFromJson(data: any): Score {
+    const performanceCalculations: PerformanceCalculation[] = data["performance_calculations"].map(performanceCalculationFromJson);
     return {
         id: data["id"],
         beatmap:
@@ -109,8 +110,8 @@ export function scoreFromJson(data: any): Score {
         approachRate: data["approach_rate"],
         overallDifficulty: data["overall_difficulty"],
         result: data["result"],
-        performanceTotal: data["performance_total"],
-        difficultyTotal: data["difficulty_total"],
+        performanceTotal: performanceCalculations.at(0)?.performanceValues.find((value) => value["name"] === "total")?.value ?? 0,
+        difficultyTotal: performanceCalculations.at(0)?.difficultyCalculation.difficultyValues.find((value) => value["name"] === "total")?.value ?? 0,
         performanceCalculations: data["performance_calculations"].map(performanceCalculationFromJson),
     };
 }

--- a/src/store/models/profiles/deserialisers.ts
+++ b/src/store/models/profiles/deserialisers.ts
@@ -1,4 +1,4 @@
-import { OsuUser, UserStats, Beatmap, Score, ScoreFilter } from "./types";
+import { Beatmap, DifficultyCalculation, DifficultyValue, OsuUser, PerformanceCalculation, PerformanceValue, Score, ScoreFilter, UserStats } from "./types";
 
 export function osuUserFromJson(data: any): OsuUser {
     return {
@@ -111,6 +111,7 @@ export function scoreFromJson(data: any): Score {
         result: data["result"],
         performanceTotal: data["performance_total"],
         difficultyTotal: data["difficulty_total"],
+        performanceCalculations: data["performance_calculations"].map(performanceCalculationFromJson),
     };
 }
 
@@ -141,5 +142,37 @@ export function scoreFilterFromJson(data: any): ScoreFilter {
         highestAccuracy: data["highest_accuracy"],
         lowestLength: data["lowest_length"],
         highestLength: data["highest_length"],
+    };
+}
+
+export function difficultyCalculationFromJson(data: any): DifficultyCalculation {
+    return {
+        calculatorEngine: data["calculator_engine"],
+        calculatorVersion: data["calculator_version"],
+        mods: data["mods"],
+        difficultyValues: data["difficulty_values"].map(difficultyValueFromJson),
+    };
+}
+
+export function difficultyValueFromJson(data: any): DifficultyValue {
+    return {
+        name: data["name"],
+        value: data["value"],
+    };
+}
+
+export function performanceCalculationFromJson(data: any): PerformanceCalculation {
+    return {
+        calculatorEngine: data["calculator_engine"],
+        calculatorVersion: data["calculator_version"],
+        performanceValues: data["performance_values"].map(performanceValueFromJson),
+        difficultyCalculation: difficultyCalculationFromJson(data["difficulty_calculation"]),
+    };
+}
+
+export function performanceValueFromJson(data: any): PerformanceValue {
+    return {
+        name: data["name"],
+        value: data["value"],
     };
 }

--- a/src/store/models/profiles/types.ts
+++ b/src/store/models/profiles/types.ts
@@ -80,7 +80,6 @@ export interface Score {
     overallDifficulty: number;
     result: ScoreResult;
     performanceTotal: number;
-    nochokePerformanceTotal: number;
     difficultyTotal: number;
     performanceCalculations: PerformanceCalculation[];
 }

--- a/src/store/models/profiles/types.ts
+++ b/src/store/models/profiles/types.ts
@@ -1,5 +1,5 @@
-import { ScoreResult, AllowedBeatmapStatus } from "./enums";
 import { BeatmapStatus, Gamemode, Mods } from "../common/enums";
+import { AllowedBeatmapStatus, ScoreResult } from "./enums";
 
 export interface OsuUser {
     id: number;
@@ -82,6 +82,7 @@ export interface Score {
     performanceTotal: number;
     nochokePerformanceTotal: number;
     difficultyTotal: number;
+    performanceCalculations: PerformanceCalculation[];
 }
 
 export interface ScoreFilter {
@@ -102,4 +103,28 @@ export interface ScoreFilter {
     highestAccuracy: number | null;
     lowestLength: number | null;
     highestLength: number | null;
+}
+
+export interface DifficultyCalculation {
+    calculatorEngine: string;
+    calculatorVersion: string;
+    mods: Mods;
+    difficultyValues: DifficultyValue[];
+}
+
+export interface DifficultyValue {
+    name: string;
+    value: number;
+}
+
+export interface PerformanceCalculation {
+    calculatorEngine: string;
+    calculatorVersion: string;
+    performanceValues: PerformanceValue[];
+    difficultyCalculation: DifficultyCalculation;
+}
+
+export interface PerformanceValue {
+    name: string;
+    value: number;
 }

--- a/src/store/models/profiles/types.ts
+++ b/src/store/models/profiles/types.ts
@@ -51,7 +51,6 @@ export interface Beatmap {
     submissionDate: Date;
     approvalDate: Date;
     lastUpdated: Date;
-    difficultyTotal: number;
 }
 
 export interface Score {

--- a/src/store/users/store.ts
+++ b/src/store/users/store.ts
@@ -1,29 +1,29 @@
-import { observable, makeAutoObservable, flow, flowResult } from "mobx";
+import { flow, flowResult, makeAutoObservable, observable } from "mobx";
 import ojsama from "ojsama";
 
 import http from "../../http";
 import notify from "../../notifications";
 
-import { UserStats, Score, ScoreFilter } from "../models/profiles/types";
-import { Membership } from "../models/leaderboards/types";
-import {
-    userStatsFromJson,
-    scoreFromJson,
-} from "../models/profiles/deserialisers";
-import { membershipFromJson } from "../models/leaderboards/deserialisers";
+import { getBeatmap, setBeatmap } from "../../beatmapCache";
 import {
     calculateAccuracy,
-    calculateBpm,
-    calculateLength,
-    calculateCircleSize,
     calculateApproachRate,
+    calculateBpm,
+    calculateCircleSize,
+    calculateLength,
     calculateOverallDifficulty,
 } from "../../utils/osu";
-import { getBeatmap, setBeatmap } from "../../beatmapCache";
+import { getScoreResult } from "../../utils/osuchan";
 import { Gamemode, Mods } from "../models/common/enums";
+import { membershipFromJson } from "../models/leaderboards/deserialisers";
+import { Membership } from "../models/leaderboards/types";
+import {
+    scoreFromJson,
+    userStatsFromJson,
+} from "../models/profiles/deserialisers";
 import { ScoreSet } from "../models/profiles/enums";
-import { unchokeForScoreSet, getScoreResult } from "../../utils/osuchan";
-import { ResourceStatus, PaginatedResourceStatus } from "../status";
+import { Score, ScoreFilter, UserStats } from "../models/profiles/types";
+import { PaginatedResourceStatus, ResourceStatus } from "../status";
 
 function calculateScoreStyleValue(values: number[]) {
     let weighting_value = 0;
@@ -64,11 +64,11 @@ export class UsersStore {
     get extraPerformance() {
         return this.currentUserStats
             ? this.currentUserStats.pp -
-                  this.scores.reduce(
-                      (total, score, i) =>
-                          total + score.performanceTotal * 0.95 ** i,
-                      0
-                  )
+            this.scores.reduce(
+                (total, score, i) =>
+                    total + score.performanceTotal * 0.95 ** i,
+                0
+            )
             : 0;
     }
 
@@ -350,9 +350,6 @@ export class UsersStore {
             let scores: Score[] = scoresResponse.data.map((data: any) =>
                 scoreFromJson(data)
             );
-
-            // transform scores into their intended form for abnormal score sets
-            scores = unchokeForScoreSet(scores, scoreSet);
 
             this.sandboxScores.replace(scores);
 

--- a/src/store/users/store.ts
+++ b/src/store/users/store.ts
@@ -431,15 +431,9 @@ export class UsersStore {
             n50: score.count50,
             nmiss: score.countMiss,
         });
-        const nochokePp = ojsama.ppv2({
-            stars,
-            n100: score.count100,
-            n50: score.count50,
-        });
 
         score.difficultyTotal = stars.total;
         score.performanceTotal = pp.total;
-        score.nochokePerformanceTotal = nochokePp.total;
 
         // Sort observable array
         this.sandboxScores.replace(

--- a/src/utils/osuchan.ts
+++ b/src/utils/osuchan.ts
@@ -1,11 +1,9 @@
-import {
-    ScoreResult,
-    ScoreSet,
-    AllowedBeatmapStatus,
-} from "../store/models/profiles/enums";
-import { Score, ScoreFilter } from "../store/models/profiles/types";
-import { calculateAccuracy } from "./osu";
 import { Mods } from "../store/models/common/enums";
+import {
+    AllowedBeatmapStatus,
+    ScoreResult,
+} from "../store/models/profiles/enums";
+import { ScoreFilter } from "../store/models/profiles/types";
 
 export function getScoreResult(
     countMiss: number,
@@ -29,39 +27,6 @@ export function getScoreResult(
     } else {
         return ScoreResult.Clear;
     }
-}
-
-export function unchokeScore(score: Score) {
-    // some slight assumptions here about combo but its close enough
-    score.count300 += score.countMiss;
-    score.countMiss = 0;
-    score.bestCombo = score.beatmap!.maxCombo;
-    score.accuracy = calculateAccuracy(
-        score.gamemode,
-        score.count300,
-        score.count100,
-        score.count50,
-        score.countMiss
-    );
-    score.performanceTotal = score.nochokePerformanceTotal;
-    score.result = ScoreResult.Perfect;
-
-    return score;
-}
-
-export function unchokeForScoreSet(scores: Score[], scoreSet: ScoreSet) {
-    switch (scoreSet) {
-        case ScoreSet.AlwaysFullCombo:
-            scores = scores.map((score) => unchokeScore(score));
-            break;
-        case ScoreSet.NeverChoke:
-            scores = scores.map((score) =>
-                score.result & ScoreResult.Choke ? unchokeScore(score) : score
-            );
-            break;
-    }
-
-    return scores;
 }
 
 export function scoreFilterIsDefault(scoreFilter: ScoreFilter) {


### PR DESCRIPTION
## Why?

Now we can safely get rid of the old fields from the backend!

## Changes

- Remove fields:
    - `Beatmap.difficultyTotal`
    - `Score.nochokePerformanceTotal`
- Remove unchoking functionality (now done on the backend)
- Remove gamemode restriction for showing difficulty on scores
- Add new diffcalc models to `Score`
- Use new diffcalc models to populate `Score.performanceTotal` and `Score.difficultyTotal` fields