### PR TITLE
Fix sometimes displaying wrong diffcalc

### DIFF
--- a/src/store/models/profiles/deserialisers.ts
+++ b/src/store/models/profiles/deserialisers.ts
@@ -72,6 +72,12 @@ export function beatmapFromJson(data: any): Beatmap {
 
 export function scoreFromJson(data: any): Score {
     const performanceCalculations: PerformanceCalculation[] = data["performance_calculations"].map(performanceCalculationFromJson);
+    const defaultPerformanceCalculation = performanceCalculations.find(calc => [
+        "rosu-pp-py",
+        "osu.Game.Rulesets.Taiko",
+        "osu.Game.Rulesets.Catch",
+        "osu.Game.Rulesets.Mania"
+    ].includes(calc["calculatorEngine"])) ?? performanceCalculations.at(0);
     return {
         id: data["id"],
         beatmap:
@@ -109,8 +115,8 @@ export function scoreFromJson(data: any): Score {
         approachRate: data["approach_rate"],
         overallDifficulty: data["overall_difficulty"],
         result: data["result"],
-        performanceTotal: performanceCalculations.at(0)?.performanceValues.find((value) => value["name"] === "total")?.value ?? 0,
-        difficultyTotal: performanceCalculations.at(0)?.difficultyCalculation.difficultyValues.find((value) => value["name"] === "total")?.value ?? 0,
+        performanceTotal: defaultPerformanceCalculation?.performanceValues.find((value) => value["name"] === "total")?.value ?? 0,
+        difficultyTotal: defaultPerformanceCalculation?.difficultyCalculation.difficultyValues.find((value) => value["name"] === "total")?.value ?? 0,
         performanceCalculations: data["performance_calculations"].map(performanceCalculationFromJson),
     };
 }


### PR DESCRIPTION
## Why?

Scores set since the new calc rollout are displaying with the wrong calc in the frontend.

## Changes

- Default to `rosu-pp-py` for standard, or lazer calc for non-standard, instead of first in list