### PR TITLE
Support leaderboard diffcalc

### DIFF
--- a/src/Osuchan/Leaderboards/Leaderboard/LeaderboardHome.tsx
+++ b/src/Osuchan/Leaderboards/Leaderboard/LeaderboardHome.tsx
@@ -1,43 +1,43 @@
-import { useEffect, useState } from "react";
-import {
-    useParams,
-    Route,
-    useRouteMatch,
-    useHistory,
-    Redirect,
-} from "react-router-dom";
 import { Observer, observer } from "mobx-react-lite";
-import styled from "styled-components";
+import { useEffect, useState } from "react";
 import { Helmet } from "react-helmet";
-
-import { formatTime, formatGamemodeName } from "../../../utils/formatting";
-import { ScoreFilter } from "../../../store/models/profiles/types";
 import {
-    Surface,
+    Redirect,
+    Route,
+    useHistory,
+    useParams,
+    useRouteMatch,
+} from "react-router-dom";
+import styled from "styled-components";
+
+import {
+    AbsoluteDate,
     Button,
-    LoadingPage,
-    UnstyledLink,
     Label,
     LabelGroup,
-    VerticalButtonGroup,
+    LoadingPage,
     ModIcons,
-    AbsoluteDate,
+    Surface,
+    UnstyledLink,
+    VerticalButtonGroup,
 } from "../../../components";
-import TopScores from "./TopScores";
-import Rankings from "./Rankings";
-import { LeaderboardAccessType } from "../../../store/models/leaderboards/enums";
 import { Gamemode, Mods } from "../../../store/models/common/enums";
+import { LeaderboardAccessType } from "../../../store/models/leaderboards/enums";
 import {
     AllowedBeatmapStatus,
     ScoreSet,
 } from "../../../store/models/profiles/enums";
-import { scoreFilterIsDefault } from "../../../utils/osuchan";
+import { ScoreFilter } from "../../../store/models/profiles/types";
+import { ResourceStatus } from "../../../store/status";
+import { formatCalculatorEngine, formatDiffcalcValueName, formatGamemodeName, formatTime } from "../../../utils/formatting";
+import { useAutorun, useStore } from "../../../utils/hooks";
 import { gamemodeIdFromName } from "../../../utils/osu";
+import { scoreFilterIsDefault } from "../../../utils/osuchan";
+import EditLeaderboardModal from "./EditLeaderboardModal";
 import ManageInvitesModal from "./ManageInvitesModal";
 import MemberModal from "./MemberModal";
-import { ResourceStatus } from "../../../store/status";
-import EditLeaderboardModal from "./EditLeaderboardModal";
-import { useAutorun, useStore } from "../../../utils/hooks";
+import Rankings from "./Rankings";
+import TopScores from "./TopScores";
 
 const LeaderboardSurface = styled(Surface)`
     display: flex;
@@ -152,11 +152,11 @@ const LeaderboardFilters = observer((props: LeaderboardFiltersProps) => {
             )}
             {scoreFilter.allowedBeatmapStatus ===
                 AllowedBeatmapStatus.LovedOnly && (
-                <>
-                    <ScoreFilterName>Beatmap Status</ScoreFilterName>
-                    <ScoreFilterValue>Loved</ScoreFilterValue>
-                </>
-            )}
+                    <>
+                        <ScoreFilterName>Beatmap Status</ScoreFilterName>
+                        <ScoreFilterValue>Loved</ScoreFilterValue>
+                    </>
+                )}
             {/* Beatmap date */}
             {scoreFilter.oldestBeatmapDate !== null && (
                 <>
@@ -357,15 +357,15 @@ const LeaderboardButtons = observer(() => {
                                 {(leaderboard!.accessType ===
                                     LeaderboardAccessType.PublicInviteOnly ||
                                     leaderboard!.accessType ===
-                                        LeaderboardAccessType.Private) && (
-                                    <Button
-                                        as={UnstyledLink}
-                                        to={`${match.url}/invites`}
-                                        type="button"
-                                    >
-                                        Manage Invites
-                                    </Button>
-                                )}
+                                    LeaderboardAccessType.Private) && (
+                                        <Button
+                                            as={UnstyledLink}
+                                            to={`${match.url}/invites`}
+                                            type="button"
+                                        >
+                                            Manage Invites
+                                        </Button>
+                                    )}
 
                                 <Button
                                     negative
@@ -491,20 +491,23 @@ const LeaderboardHome = observer(() => {
                                             </Label>
                                             {leaderboard.scoreSet !==
                                                 ScoreSet.Normal && (
-                                                <Label special>
-                                                    {leaderboard.scoreSet ===
-                                                        ScoreSet.NeverChoke &&
-                                                        "Never Choke"}
-                                                    {leaderboard.scoreSet ===
-                                                        ScoreSet.AlwaysFullCombo &&
-                                                        "Always Full Combo"}
-                                                </Label>
-                                            )}
+                                                    <Label special>
+                                                        {leaderboard.scoreSet ===
+                                                            ScoreSet.NeverChoke &&
+                                                            "Never Choke"}
+                                                        {leaderboard.scoreSet ===
+                                                            ScoreSet.AlwaysFullCombo &&
+                                                            "Always Full Combo"}
+                                                    </Label>
+                                                )}
                                             {!leaderboard.allowPastScores && (
                                                 <Label special>
                                                     Only scores after joining
                                                 </Label>
                                             )}
+                                            <Label>
+                                                {formatCalculatorEngine(leaderboard.calculatorEngine)} ({formatDiffcalcValueName(leaderboard.primaryPerformanceValue)})
+                                            </Label>
                                         </LabelGroup>
                                     </LeaderboardInfoRow>
                                     {leaderboard.owner && (
@@ -562,7 +565,7 @@ const LeaderboardHome = observer(() => {
                                 {props.match !== null &&
                                     leaderboard &&
                                     leaderboard.ownerId !==
-                                        meStore.user?.osuUserId && (
+                                    meStore.user?.osuUserId && (
                                         <Redirect to={match.url} />
                                     )}
                             </>

--- a/src/components/layout/ScoreModal.tsx
+++ b/src/components/layout/ScoreModal.tsx
@@ -1,9 +1,13 @@
 import styled from "styled-components";
 
+import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { observer } from "mobx-react-lite";
+import { Fragment, useState } from "react";
 import { BeatmapStatus, Gamemode } from "../../store/models/common/enums";
 import { Score } from "../../store/models/profiles/types";
-import { formatScoreResult, formatTime } from "../../utils/formatting";
+import { formatCalculatorEngine, formatDiffcalcValueName, formatScoreResult, formatTime } from "../../utils/formatting";
+import { Button } from "../forms/Button";
 import { BasicModal } from "./BasicModal";
 import { DataCell, DataTable } from "./DataTable";
 import { ModIcons } from "./ModIcons";
@@ -90,9 +94,59 @@ const Performance = styled.span`
 
 const Result = styled.span``;
 
+const DetailsBar = styled(Button)`
+    display: block;
+    width: 100%;
+    border-radius: 0;
+`;
+
+const Chevron = styled(FontAwesomeIcon)`
+    transform: scaleY(${(props: ChevronProps) => (props.open ? "1" : "-1")});
+    transition: transform 0.2s linear;
+`;
+
+interface ChevronProps {
+    open?: boolean;
+}
+
+const DetailsCollapser = styled.div<DetailsCollapserProps>`
+    overflow: hidden;
+    max-height: ${(props) => (props.open ? "500px" : "0px")};
+    transition: max-height 0.3s linear;
+`;
+
+interface DetailsCollapserProps {
+    open?: boolean;
+}
+
+const DetailsContainer = styled.div`
+    padding: 10px;
+`;
+
+const DiffcalcHeader = styled.h3`
+    text-align: center;
+`;
+
+const DiffcalcDetailsContainer = styled.div`
+    display: flex;
+    justify-content: space-between;
+`;
+
+const DifficultyDataTable = styled(DataTable)`
+    max-width: 300px;
+    font-size: 1.1em;
+`;
+
+const PerformanceDataTable = styled(DataTable)`
+    max-width: 300px;
+    font-size: 1.1em;
+`;
+
 export const ScoreModal = observer((props: ScoreModalProps) => {
     const score = props.score;
     const beatmap = score.beatmap!;
+
+    const [detailsOpen, setDetailsOpen] = useState(false);
 
     return (
         <BasicModal open={props.open} onClose={props.onClose}>
@@ -228,6 +282,60 @@ export const ScoreModal = observer((props: ScoreModalProps) => {
                     <Result>{formatScoreResult(score.result)}</Result>
                 </ScoreInfo>
             </InfoContainer>
+            <DetailsBar action={() => setDetailsOpen(!detailsOpen)}>
+                <Chevron
+                    open={detailsOpen}
+                    icon={faChevronDown}
+                    size="sm"
+                />
+                {detailsOpen ? (
+                    " Hide difficulty and performance details "
+                ) : (
+                    " Show difficulty and performance details "
+                )}
+                <Chevron
+                    open={detailsOpen}
+                    icon={faChevronDown}
+                    size="sm"
+                />
+            </DetailsBar>
+            <DetailsCollapser open={detailsOpen}>
+                <DetailsContainer>
+                    {score.performanceCalculations.map(performanceCalculation => (
+                        <Fragment key={performanceCalculation.calculatorEngine}>
+                            <DiffcalcHeader>{formatCalculatorEngine(performanceCalculation.calculatorEngine)}</DiffcalcHeader>
+                            <DiffcalcDetailsContainer>
+                                <DifficultyDataTable>
+                                    {performanceCalculation.difficultyCalculation.difficultyValues.map((value) => (
+                                        <tr key={value.name}>
+                                            <td>{formatDiffcalcValueName(value.name)}</td>
+                                            <DataCell>
+                                                <NumberFormat
+                                                    value={value.value}
+                                                    decimalPlaces={2}
+                                                /> stars
+                                            </DataCell>
+                                        </tr>
+                                    ))}
+                                </DifficultyDataTable>
+                                <PerformanceDataTable>
+                                    {performanceCalculation.performanceValues.map((value) => (
+                                        <tr key={value.name}>
+                                            <td>{formatDiffcalcValueName(value.name)}</td>
+                                            <DataCell>
+                                                <NumberFormat
+                                                    value={value.value}
+                                                    decimalPlaces={0}
+                                                />pp
+                                            </DataCell>
+                                        </tr>
+                                    ))}
+                                </PerformanceDataTable>
+                            </DiffcalcDetailsContainer>
+                        </Fragment>
+                    ))}
+                </DetailsContainer>
+            </DetailsCollapser>
         </BasicModal>
     );
 });

--- a/src/store/leaderboards/detail/store.ts
+++ b/src/store/leaderboards/detail/store.ts
@@ -114,7 +114,7 @@ export class DetailStore {
                 }
             );
             const scores: Score[] = scoresResponse.data.map((data: any) =>
-                scoreFromJson(data)
+                scoreFromJson(data, leaderboard.calculatorEngine, leaderboard.primaryPerformanceValue)
             );
 
             this.leaderboard = leaderboard;
@@ -369,7 +369,7 @@ export class DetailStore {
                 `${this.resourceUrl}/members/${userId}/scores`
             );
             const scores: Score[] = scoresResponse.data.map((data: any) =>
-                scoreFromJson(data)
+                scoreFromJson(data, this.leaderboard?.calculatorEngine, this.leaderboard?.primaryPerformanceValue)
             );
 
             this.membership = membership;

--- a/src/store/models/leaderboards/deserialisers.ts
+++ b/src/store/models/leaderboards/deserialisers.ts
@@ -1,8 +1,8 @@
-import { Leaderboard, Membership, Invite } from "./types";
 import {
     osuUserFromJson,
     scoreFilterFromJson,
 } from "../profiles/deserialisers";
+import { Invite, Leaderboard, Membership } from "./types";
 
 export function leaderboardFromJson(data: any): Leaderboard {
     return {
@@ -16,30 +16,32 @@ export function leaderboardFromJson(data: any): Leaderboard {
         allowPastScores: data["allow_past_scores"],
         memberCount: data["member_count"],
         archived: data["archived"],
+        calculatorEngine: data["calculator_engine"],
+        primaryPerformanceValue: data["primary_performance_value"],
         scoreFilter:
             data["score_filter"] === null
                 ? null
                 : typeof data["score_filter"] === "object"
-                ? scoreFilterFromJson(data["score_filter"])
-                : null,
+                    ? scoreFilterFromJson(data["score_filter"])
+                    : null,
         scoreFilterId:
             data["score_filter"] === null
                 ? null
                 : typeof data["score_filter"] === "object"
-                ? data["score_filter"]["id"]
-                : data["score_filter"],
+                    ? data["score_filter"]["id"]
+                    : data["score_filter"],
         owner:
             data["owner"] === null
                 ? null
                 : typeof data["owner"] === "object"
-                ? osuUserFromJson(data["owner"])
-                : null,
+                    ? osuUserFromJson(data["owner"])
+                    : null,
         ownerId:
             data["owner"] === null
                 ? null
                 : typeof data["owner"] === "object"
-                ? data["owner"]["id"]
-                : data["owner"],
+                    ? data["owner"]["id"]
+                    : data["owner"],
         creationTime: new Date(data["creation_time"]),
     };
 }

--- a/src/store/models/leaderboards/types.ts
+++ b/src/store/models/leaderboards/types.ts
@@ -1,7 +1,7 @@
-import { OsuUser, ScoreFilter } from "../profiles/types";
-import { LeaderboardAccessType } from "./enums";
 import { Gamemode } from "../common/enums";
 import { ScoreSet } from "../profiles/enums";
+import { OsuUser, ScoreFilter } from "../profiles/types";
+import { LeaderboardAccessType } from "./enums";
 
 export interface Leaderboard {
     id: number;
@@ -14,6 +14,8 @@ export interface Leaderboard {
     allowPastScores: boolean;
     memberCount: number | null;
     archived: boolean;
+    calculatorEngine: string;
+    primaryPerformanceValue: string;
     scoreFilter: ScoreFilter | null;
     scoreFilterId: number;
     owner: OsuUser | null;

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -1,6 +1,6 @@
-import { modsAsArray } from "./osu";
-import { ScoreResult } from "../store/models/profiles/enums";
 import { Gamemode, Mods } from "../store/models/common/enums";
+import { ScoreResult } from "../store/models/profiles/enums";
+import { modsAsArray } from "./osu";
 
 export function formatTime(seconds: number) {
     // convert seconds to MM:SS format
@@ -200,4 +200,25 @@ export function formatGamemodeNameShort(gamemodeId: Gamemode) {
         default:
             return "Unknown";
     }
+}
+
+export function formatCalculatorEngine(calculatorEngine: string) {
+    switch (calculatorEngine) {
+        case "osu.Game.Rulesets.Osu":
+        case "osu.Game.Rulesets.Taiko":
+        case "osu.Game.Rulesets.Catch":
+        case "osu.Game.Rulesets.Mania":
+            return "ppv2";
+        case "https://github.com/Syriiin/osu":
+            return "PP+";
+        default:
+            return calculatorEngine;
+    }
+}
+
+export function formatDiffcalcValueName(name: string) {
+    // convert `camelCase` diffcalc value names to `Title Case With Spaces`
+    return name // flowAim
+        .replace(/([A-Z])/g, " $1") // flow Aim
+        .replace(/^./, (str) => str.toUpperCase()); // Flow Aim
 }


### PR DESCRIPTION
## Why?

Leaderboards support setting a difficulty calculator now, so we need the frontend to show that.

## Changes

- Display leaderboard diffcalc in a label
- Add expandable diffcalc details section in score modal
- Display pp in score rows based on leaderboard diffcalc