### PR TITLE
Update pp+ calculator engine name

### DIFF
--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -209,7 +209,7 @@ export function formatCalculatorEngine(calculatorEngine: string) {
         case "osu.Game.Rulesets.Catch":
         case "osu.Game.Rulesets.Mania":
             return "ppv2";
-        case "https://github.com/Syriiin/osu":
+        case "https://github.com/Syriiin/osu/tree/performanceplus":
             return "PP+";
         default:
             return calculatorEngine;


### PR DESCRIPTION
## Why?

It be updated!

## Changes

- Update pp+ engine name from `https://github.com/Syriiin/osu` to `https://github.com/Syriiin/osu/tree/performanceplus`