### PR TITLE
Fix score modal cover image load resizing

### DIFF
--- a/src/components/layout/ScoreModal.tsx
+++ b/src/components/layout/ScoreModal.tsx
@@ -16,6 +16,8 @@ import { TimeAgo } from "./TimeAgo";
 
 const BannerImage = styled.img`
     width: 100%;
+    min-width: 900px;
+    min-height: 250px;
     border-top-left-radius: 5px;
     border-top-right-radius: 5px;
 `;


### PR DESCRIPTION
## Why?

It's annoying when elements move after things load.

## Changes

- Set min-width and min-height to expected size of cover image when loaded