### PR TITLE
Add more event styling

### DIFF
--- a/src/Osuchan/Leaderboards/Leaderboard/LeaderboardHome.tsx
+++ b/src/Osuchan/Leaderboards/Leaderboard/LeaderboardHome.tsx
@@ -480,6 +480,11 @@ const LeaderboardHome = observer(() => {
                                         <LeaderboardInfoRow>
                                             {/* Labels */}
                                             <LabelGroup>
+                                                {leaderboard.isEvent && (
+                                                    <Label special>
+                                                        EVENT
+                                                    </Label>
+                                                )}
                                                 {leaderboard.archived && (
                                                     <Label negative>
                                                         ARCHIVED
@@ -533,7 +538,7 @@ const LeaderboardHome = observer(() => {
                                                 </Label>
                                             </LabelGroup>
                                         </LeaderboardInfoRow>
-                                        {leaderboard.owner && (
+                                        {!leaderboard.isEvent && leaderboard.owner && (
                                             <LeaderboardInfoRow>
                                                 Owned by{" "}
                                                 <Owner>

--- a/src/Osuchan/Leaderboards/Leaderboard/LeaderboardHome.tsx
+++ b/src/Osuchan/Leaderboards/Leaderboard/LeaderboardHome.tsx
@@ -8,7 +8,7 @@ import {
     useParams,
     useRouteMatch,
 } from "react-router-dom";
-import styled from "styled-components";
+import styled, { ThemeProvider } from "styled-components";
 
 import {
     AbsoluteDate,
@@ -41,6 +41,10 @@ import {
     modsJsonFromModAcronyms,
 } from "../../../utils/osu";
 import { scoreFilterIsDefault } from "../../../utils/osuchan";
+import {
+    setCssCustomProperties,
+    clearCssCustomProperties,
+} from "../../../utils/general";
 import EditLeaderboardModal from "./EditLeaderboardModal";
 import ManageInvitesModal from "./ManageInvitesModal";
 import MemberModal from "./MemberModal";
@@ -436,6 +440,19 @@ const LeaderboardHome = observer(() => {
         detailStore.loadLeaderboard(leaderboardType, gamemode, leaderboardId);
     }, [detailStore, leaderboardType, gamemode, leaderboardId]);
 
+    useEffect(() => {
+        const shouldApply = leaderboard?.isEvent && leaderboard?.customColours;
+        const coloursToApply = shouldApply ? leaderboard.customColours : null;
+        if (coloursToApply) {
+            setCssCustomProperties(coloursToApply);
+        }
+        return () => {
+            if (coloursToApply) {
+                clearCssCustomProperties(coloursToApply);
+            }
+        };
+    }, [leaderboard]);
+
     useAutorun(() => {
         if (meStore.user?.osuUserId) {
             detailStore.loadUserMembership(meStore.user?.osuUserId);
@@ -461,125 +478,139 @@ const LeaderboardHome = observer(() => {
             )}
             {detailStore.loadingStatus === ResourceStatus.Loaded &&
                 leaderboard && (
-                    <>
-                        {/*Leaderboard Details */}
-                        <LeaderboardSurface>
-                            <LeaderboardDetailsContainer>
-                                <LeaderboardInfoContainer>
-                                    {leaderboard.iconUrl && (
-                                        <LeaderboardIcon
-                                            src={leaderboard.iconUrl}
-                                        />
-                                    )}
-                                    <LeaderboardInfo>
-                                        <LeaderboardInfoRow>
-                                            <LeaderboardName>
-                                                {leaderboard.name}
-                                            </LeaderboardName>
-                                        </LeaderboardInfoRow>
-                                        <LeaderboardInfoRow>
-                                            {/* Labels */}
-                                            <LabelGroup>
-                                                {leaderboard.isEvent && (
-                                                    <Label special>
-                                                        EVENT
-                                                    </Label>
-                                                )}
-                                                {leaderboard.archived && (
-                                                    <Label negative>
-                                                        ARCHIVED
-                                                    </Label>
-                                                )}
-                                                <Label>
-                                                    {formatGamemodeName(
-                                                        leaderboard.gamemode
-                                                    )}
-                                                </Label>
-                                                <Label>
-                                                    {leaderboard.accessType ===
-                                                        LeaderboardAccessType.Global &&
-                                                        "Global"}
-                                                    {leaderboard.accessType ===
-                                                        LeaderboardAccessType.Public &&
-                                                        "Public"}
-                                                    {leaderboard.accessType ===
-                                                        LeaderboardAccessType.PublicInviteOnly &&
-                                                        "Invite-Only"}
-                                                    {leaderboard.accessType ===
-                                                        LeaderboardAccessType.Private &&
-                                                        "Private"}
-                                                </Label>
-                                                {leaderboard.scoreSet !==
-                                                    ScoreSet.Normal && (
-                                                    <Label special>
-                                                        {leaderboard.scoreSet ===
-                                                            ScoreSet.NeverChoke &&
-                                                            "Never Choke"}
-                                                        {leaderboard.scoreSet ===
-                                                            ScoreSet.AlwaysFullCombo &&
-                                                            "Always Full Combo"}
-                                                    </Label>
-                                                )}
-                                                {!leaderboard.allowPastScores && (
-                                                    <Label special>
-                                                        Only scores after
-                                                        joining
-                                                    </Label>
-                                                )}
-                                                <Label>
-                                                    {formatCalculatorEngine(
-                                                        leaderboard.calculatorEngine
-                                                    )}{" "}
-                                                    (
-                                                    {formatDiffcalcValueName(
-                                                        leaderboard.primaryPerformanceValue
-                                                    )}
-                                                    )
-                                                </Label>
-                                            </LabelGroup>
-                                        </LeaderboardInfoRow>
-                                        {!leaderboard.isEvent && leaderboard.owner && (
-                                            <LeaderboardInfoRow>
-                                                Owned by{" "}
-                                                <Owner>
-                                                    {leaderboard.owner.username}
-                                                </Owner>
-                                            </LeaderboardInfoRow>
+                    <ThemeProvider
+                        theme={(theme) =>
+                            leaderboard.isEvent
+                                ? {
+                                      ...theme,
+                                      colours: {
+                                          ...theme.colours,
+                                          ...leaderboard.customColours,
+                                      },
+                                  }
+                                : theme
+                        }
+                    >
+                        <>
+                            {/*Leaderboard Details */}
+                            <LeaderboardSurface>
+                                <LeaderboardDetailsContainer>
+                                    <LeaderboardInfoContainer>
+                                        {leaderboard.iconUrl && (
+                                            <LeaderboardIcon
+                                                src={leaderboard.iconUrl}
+                                            />
                                         )}
-                                    </LeaderboardInfo>
-                                </LeaderboardInfoContainer>
-                                <Description>
-                                    {leaderboard.description}
-                                </Description>
-                            </LeaderboardDetailsContainer>
-                            {leaderboard.scoreFilter &&
-                                !scoreFilterIsDefault(
-                                    leaderboard.scoreFilter
-                                ) && (
-                                    <LeaderboardScoreFilterContainer>
-                                        <LeaderboardFilters
-                                            gamemode={leaderboard.gamemode}
-                                            scoreFilter={
-                                                leaderboard.scoreFilter
-                                            }
-                                        />
-                                    </LeaderboardScoreFilterContainer>
-                                )}
-                            {leaderboard.accessType !==
-                                LeaderboardAccessType.Global &&
-                                meStore.isAuthenticated && (
-                                    <LeaderboardButtonsContainer>
-                                        <LeaderboardButtons />
-                                    </LeaderboardButtonsContainer>
-                                )}
-                        </LeaderboardSurface>
+                                        <LeaderboardInfo>
+                                            <LeaderboardInfoRow>
+                                                <LeaderboardName>
+                                                    {leaderboard.name}
+                                                </LeaderboardName>
+                                            </LeaderboardInfoRow>
+                                            <LeaderboardInfoRow>
+                                                {/* Labels */}
+                                                <LabelGroup>
+                                                    {leaderboard.isEvent && (
+                                                        <Label special>
+                                                            EVENT
+                                                        </Label>
+                                                    )}
+                                                    {leaderboard.archived && (
+                                                        <Label negative>
+                                                            ARCHIVED
+                                                        </Label>
+                                                    )}
+                                                    <Label>
+                                                        {formatGamemodeName(
+                                                            leaderboard.gamemode
+                                                        )}
+                                                    </Label>
+                                                    <Label>
+                                                        {leaderboard.accessType ===
+                                                            LeaderboardAccessType.Global &&
+                                                            "Global"}
+                                                        {leaderboard.accessType ===
+                                                            LeaderboardAccessType.Public &&
+                                                            "Public"}
+                                                        {leaderboard.accessType ===
+                                                            LeaderboardAccessType.PublicInviteOnly &&
+                                                            "Invite-Only"}
+                                                        {leaderboard.accessType ===
+                                                            LeaderboardAccessType.Private &&
+                                                            "Private"}
+                                                    </Label>
+                                                    {leaderboard.scoreSet !==
+                                                        ScoreSet.Normal && (
+                                                        <Label special>
+                                                            {leaderboard.scoreSet ===
+                                                                ScoreSet.NeverChoke &&
+                                                                "Never Choke"}
+                                                            {leaderboard.scoreSet ===
+                                                                ScoreSet.AlwaysFullCombo &&
+                                                                "Always Full Combo"}
+                                                        </Label>
+                                                    )}
+                                                    {!leaderboard.allowPastScores && (
+                                                        <Label special>
+                                                            Only scores after
+                                                            joining
+                                                        </Label>
+                                                    )}
+                                                    <Label>
+                                                        {formatCalculatorEngine(
+                                                            leaderboard.calculatorEngine
+                                                        )}{" "}
+                                                        (
+                                                        {formatDiffcalcValueName(
+                                                            leaderboard.primaryPerformanceValue
+                                                        )}
+                                                        )
+                                                    </Label>
+                                                </LabelGroup>
+                                            </LeaderboardInfoRow>
+                                            {!leaderboard.isEvent && leaderboard.owner && (
+                                                <LeaderboardInfoRow>
+                                                    Owned by{" "}
+                                                    <Owner>
+                                                        {leaderboard.owner.username}
+                                                    </Owner>
+                                                </LeaderboardInfoRow>
+                                            )}
+                                        </LeaderboardInfo>
+                                    </LeaderboardInfoContainer>
+                                    <Description>
+                                        {leaderboard.description}
+                                    </Description>
+                                </LeaderboardDetailsContainer>
+                                {leaderboard.scoreFilter &&
+                                    !scoreFilterIsDefault(
+                                        leaderboard.scoreFilter
+                                    ) && (
+                                        <LeaderboardScoreFilterContainer>
+                                            <LeaderboardFilters
+                                                gamemode={leaderboard.gamemode}
+                                                scoreFilter={
+                                                    leaderboard.scoreFilter
+                                                }
+                                            />
+                                        </LeaderboardScoreFilterContainer>
+                                    )}
+                                {leaderboard.accessType !==
+                                    LeaderboardAccessType.Global &&
+                                    meStore.isAuthenticated && (
+                                        <LeaderboardButtonsContainer>
+                                            <LeaderboardButtons />
+                                        </LeaderboardButtonsContainer>
+                                    )}
+                            </LeaderboardSurface>
 
-                        {/* Top Scores */}
-                        <TopScores scores={detailStore.leaderboardScores} />
+                            {/* Top Scores */}
+                            <TopScores scores={detailStore.leaderboardScores} />
 
-                        {/* Rankings */}
-                        <Rankings memberships={detailStore.rankings} />
-                    </>
+                            {/* Rankings */}
+                            <Rankings memberships={detailStore.rankings} />
+                        </>
+                    </ThemeProvider>
                 )}
             {detailStore.loadingStatus === ResourceStatus.Error && (
                 <h3>Leaderboard not found!</h3>

--- a/src/osuchanTheme.ts
+++ b/src/osuchanTheme.ts
@@ -1,17 +1,20 @@
 import { DefaultTheme } from "styled-components";
 
+const getColour = (key: string, fallback: string) =>
+    `var(--colours-${key}, ${fallback})`;
+
 export const osuchanTheme: DefaultTheme = {
     colours: {
-        pillow: "#3A3ACC",
-        currant: "#574566",
-        mystic: "#A02EFF",
-        timber: "#D2B66F",
-        mango: "#FFAF2E",
-        positive: "#2FCC6A",
-        warning: "#CCAE25",
-        negative: "#CC544E",
-        foreground: "#363663",
-        midground: "#29293D",
-        background: "#17171C",
+        pillow: getColour("pillow", "#3A3ACC"),
+        currant: getColour("currant", "#574566"),
+        mystic: getColour("mystic", "#A02EFF"),
+        timber: getColour("timber", "#D2B66F"),
+        mango: getColour("mango", "#FFAF2E"),
+        positive: getColour("positive", "#2FCC6A"),
+        warning: getColour("warning", "#CCAE25"),
+        negative: getColour("negative", "#CC544E"),
+        foreground: getColour("foreground", "#363663"),
+        midground: getColour("midground", "#29293D"),
+        background: getColour("background", "#17171C"),
     },
 };

--- a/src/store/models/leaderboards/deserialisers.ts
+++ b/src/store/models/leaderboards/deserialisers.ts
@@ -44,6 +44,7 @@ export function leaderboardFromJson(data: any): Leaderboard {
                     ? data["owner"]["id"]
                     : data["owner"],
         creationTime: new Date(data["creation_time"]),
+        isEvent: data["is_event"],
     };
 }
 

--- a/src/store/models/leaderboards/types.ts
+++ b/src/store/models/leaderboards/types.ts
@@ -22,6 +22,7 @@ export interface Leaderboard {
     owner: OsuUser | null;
     ownerId: number | null;
     creationTime: Date;
+    isEvent: boolean;
 }
 
 export interface Membership {

--- a/src/utils/general.ts
+++ b/src/utils/general.ts
@@ -1,3 +1,23 @@
 export function hasFlag(value: number, bitmask: number) {
     return (value & bitmask) === value;
 }
+
+export function setCssCustomProperties(
+    colours: Record<string, string>,
+    prefix = "colours"
+) {
+    const root = document.documentElement;
+    Object.entries(colours).forEach(([key, value]) => {
+        root.style.setProperty(`--${prefix}-${key}`, value);
+    });
+}
+
+export function clearCssCustomProperties(
+    colours: Record<string, string>,
+    prefix = "colours"
+) {
+    const root = document.documentElement;
+    Object.keys(colours).forEach((key) => {
+        root.style.removeProperty(`--${prefix}-${key}`);
+    });
+}


### PR DESCRIPTION
## Why?

We want further custom styling for the upcoming event.

(this is mostly hacky bandaid code that doesn't care about maintenance; we're on a tight timeline, i'm travelling and sick, and this repo is ready to be replaced by a new modern frontend as soon as time permits a rewrite)

## Changes

- Add event styling to leaderboard home page when the `is_event` flag is set
- Allow custom colours to affect the leaderboard home page when `is_event` is set
