### PR TITLE
Add show more scores button to leaderboard home

### DIFF
--- a/src/Osuchan/Leaderboards/Leaderboard/TopScores.tsx
+++ b/src/Osuchan/Leaderboards/Leaderboard/TopScores.tsx
@@ -1,7 +1,8 @@
+import { useState } from "react";
 import styled from "styled-components";
 import { observer } from "mobx-react-lite";
 
-import { Surface, SurfaceTitle, ScoreRow } from "../../../components";
+import { Surface, SurfaceTitle, ScoreRow, Button } from "../../../components";
 import { Score } from "../../../store/models/profiles/types";
 
 const TopScoresSurface = styled(Surface)`
@@ -10,14 +11,31 @@ const TopScoresSurface = styled(Surface)`
     padding: 20px;
 `;
 
-const TopScores = observer((props: TopScoresProps) => (
-    <TopScoresSurface>
-        <SurfaceTitle>Top Scores</SurfaceTitle>
-        {props.scores.map((score, i) => (
-            <ScoreRow key={i} score={score} />
-        ))}
-    </TopScoresSurface>
-));
+const TopScores = observer((props: TopScoresProps) => {
+    const [showAllScores, setShowAllScores] = useState(false);
+
+    return (
+        <TopScoresSurface>
+            <SurfaceTitle>Top Scores</SurfaceTitle>
+            {(showAllScores
+                ? props.scores
+                : props.scores.slice(0, 5)
+            ).map((score, i) => (
+                <ScoreRow key={i} score={score} />
+            ))}
+            {props.scores.length > 5 && !showAllScores && (
+                <Button
+                    type="button"
+                    fullWidth
+                    action={() => setShowAllScores(true)}
+                >
+                    Show More
+                </Button>
+            )}
+            {props.scores.length === 0 && <p>No scores found...</p>}
+        </TopScoresSurface>
+    );
+});
 
 interface TopScoresProps {
     scores: Score[];

--- a/src/store/leaderboards/detail/store.ts
+++ b/src/store/leaderboards/detail/store.ts
@@ -105,7 +105,7 @@ export class DetailStore {
                 `${this.resourceUrl}/scores`,
                 {
                     params: {
-                        limit: moreScores ? 100 : 5,
+                        limit: 100,
                     },
                 }
             );


### PR DESCRIPTION
## Why?

The upcoming event is focusing on top scores as opposed to pp totals, so we want to be able to show more scores in the homepage.

## Changes

- Add "show more" button to the top scores panel in the leaderboard homepage
