### PR TITLE
Fix dashboard loading states

### DIFF
--- a/src/pages/COEPPRaceDashboard/index.tsx
+++ b/src/pages/COEPPRaceDashboard/index.tsx
@@ -117,17 +117,21 @@ const COEPPRaceDashboard = observer(() => {
     return (
         <>
             <title>
-                {loadingStatus === ResourceStatus.Loading
-                    ? "Loading..."
-                    : loadingStatus === ResourceStatus.Loaded && pprace
-                      ? `${pprace.name} - osu!chan`
+                {pprace
+                    ? `${pprace.name} - osu!chan`
+                    : loadingStatus === ResourceStatus.Loading
+                      ? "Loading..."
                       : loadingStatus === ResourceStatus.Error
                         ? "PP Race not found - osu!chan"
                         : "osu!chan"}
             </title>
-            {detailStore.loadingStatus === ResourceStatus.Loading && <LoadingPage />}
+            {pprace === null && detailStore.loadingStatus === ResourceStatus.Loading && (
+                <LoadingPage />
+            )}
 
-            {detailStore.loadingStatus === ResourceStatus.Error && <h3>PP Race not found!</h3>}
+            {pprace === null && detailStore.loadingStatus === ResourceStatus.Error && (
+                <h3>PP Race not found!</h3>
+            )}
 
             {detailStore.loadingStatus === ResourceStatus.Loaded && pprace && (
                 <DashboardWrapper>

--- a/src/pages/LeaderboardDashboard/index.tsx
+++ b/src/pages/LeaderboardDashboard/index.tsx
@@ -74,7 +74,7 @@ const LeaderboardDashboard = observer(() => {
 
     useEffect(() => {
         const interval = setInterval(() => {
-            void detailStore.reloadLeaderboard(true);
+            void detailStore.reloadLeaderboard(true, true);
         }, 60 * 1000);
         return () => clearInterval(interval);
     }, [detailStore]);
@@ -82,10 +82,10 @@ const LeaderboardDashboard = observer(() => {
     return (
         <>
             <title>
-                {loadingStatus === ResourceStatus.Loading
-                    ? "Loading..."
-                    : loadingStatus === ResourceStatus.Loaded && leaderboard
-                      ? `${leaderboard.name} - osu!chan`
+                {leaderboard
+                    ? `${leaderboard.name} - osu!chan`
+                    : loadingStatus === ResourceStatus.Loading
+                      ? "Loading..."
                       : loadingStatus === ResourceStatus.Error
                         ? "Leaderboard not found - osu!chan"
                         : "osu!chan"}
@@ -94,7 +94,9 @@ const LeaderboardDashboard = observer(() => {
                 <LoadingPage />
             )}
 
-            {detailStore.loadingStatus === ResourceStatus.Error && <h3>Leaderboard not found!</h3>}
+            {leaderboard === null && detailStore.loadingStatus === ResourceStatus.Error && (
+                <h3>Leaderboard not found!</h3>
+            )}
 
             {leaderboard && (
                 <ThemeProvider

--- a/src/pages/PPRaceDashboard/index.tsx
+++ b/src/pages/PPRaceDashboard/index.tsx
@@ -97,17 +97,21 @@ const PPRaceDashboard = observer(() => {
     return (
         <>
             <title>
-                {loadingStatus === ResourceStatus.Loading
-                    ? "Loading..."
-                    : loadingStatus === ResourceStatus.Loaded && pprace
-                      ? `${pprace.name} - osu!chan`
+                {pprace
+                    ? `${pprace.name} - osu!chan`
+                    : loadingStatus === ResourceStatus.Loading
+                      ? "Loading..."
                       : loadingStatus === ResourceStatus.Error
                         ? "PP Race not found - osu!chan"
                         : "osu!chan"}
             </title>
-            {detailStore.loadingStatus === ResourceStatus.Loading && <LoadingPage />}
+            {pprace === null && detailStore.loadingStatus === ResourceStatus.Loading && (
+                <LoadingPage />
+            )}
 
-            {detailStore.loadingStatus === ResourceStatus.Error && <h3>PP Race not found!</h3>}
+            {pprace === null && detailStore.loadingStatus === ResourceStatus.Error && (
+                <h3>PP Race not found!</h3>
+            )}
 
             {detailStore.loadingStatus === ResourceStatus.Loaded && pprace && (
                 <DashboardWrapper>

--- a/src/store/leaderboards/detail/store.ts
+++ b/src/store/leaderboards/detail/store.ts
@@ -63,12 +63,13 @@ export class DetailStore {
         return `/api/leaderboards/${this.leaderboardType}/${this.gamemode}/${this.leaderboardId}`;
     }
 
-    reloadLeaderboard = async (_moreScores: boolean = false) =>
+    reloadLeaderboard = async (_moreScores: boolean = false, background: boolean = false) =>
         this.loadLeaderboard(
             this.leaderboardType!,
             this.gamemode!,
             this.leaderboardId!,
             _moreScores,
+            background,
         );
 
     *loadLeaderboard(
@@ -76,8 +77,11 @@ export class DetailStore {
         gamemode: Gamemode,
         leaderboardId: number,
         _moreScores: boolean = false,
+        background: boolean = false,
     ): any {
-        this.loadingStatus = ResourceStatus.Loading;
+        if (!background) {
+            this.loadingStatus = ResourceStatus.Loading;
+        }
         this.leaderboardType = leaderboardType;
         this.gamemode = gamemode;
         this.leaderboardId = leaderboardId;
@@ -112,7 +116,9 @@ export class DetailStore {
         } catch (error: any) {
             console.log(error);
 
-            this.loadingStatus = ResourceStatus.Error;
+            if (this.leaderboard === null) {
+                this.loadingStatus = ResourceStatus.Error;
+            }
         }
     }
 

--- a/src/store/ppraces/detail/store.ts
+++ b/src/store/ppraces/detail/store.ts
@@ -58,7 +58,9 @@ export class DetailStore {
         } catch (error: any) {
             console.log(error);
 
-            this.loadingStatus = ResourceStatus.Error;
+            if (this.pprace === null) {
+                this.loadingStatus = ResourceStatus.Error;
+            }
         }
     }
 }


### PR DESCRIPTION
## Why?

Just better innit?

## Changes

- Fix leaderboard title switching to "loading" on background refresh (+ better semantics for loading states)
- Fix pp race dashboards crashing to nothing if a background refresh failed
