### PR TITLE
Fix some mutation buttons not having auth checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,4 +31,4 @@ setup:	## Installs dependencies
 build:	## Builds the project
 	npm run build
 
-ci: checkfixup lint typecheck checkformatting test build	## Runs all checks
+ci: lint typecheck checkformatting	## Runs all fast checks

--- a/src/Osuchan/Minigames/LobbyScreen.tsx
+++ b/src/Osuchan/Minigames/LobbyScreen.tsx
@@ -12,7 +12,14 @@ import {
     faUsers,
 } from "@fortawesome/free-solid-svg-icons";
 
-import { Button, Label, LoadingSection, ShortTimeAgo, Surface } from "../../components";
+import {
+    Button,
+    Label,
+    LoadingSection,
+    ShortTimeAgo,
+    Surface,
+    UnstyledLink,
+} from "../../components";
 import { ScoreModal } from "../../components/layout/ScoreModal";
 import { ModIcons } from "../../components/layout/ModIcons";
 import {
@@ -423,6 +430,12 @@ const LobbyScreen = observer((props: LobbyScreenProps) => {
         !isInOtherGame &&
         (minigame.status === MinigameStatus.Lobby ||
             minigame.status === MinigameStatus.WaitingToStart);
+    const couldJoin =
+        !meStore.isAuthenticated &&
+        playerTeamId === null &&
+        !isInOtherGame &&
+        (minigame.status === MinigameStatus.Lobby ||
+            minigame.status === MinigameStatus.WaitingToStart);
     const canLeave =
         playerTeamId !== null &&
         (minigame.status === MinigameStatus.Lobby ||
@@ -475,6 +488,12 @@ const LobbyScreen = observer((props: LobbyScreenProps) => {
                                     action={() => joinMutation.mutate(minigame.id)}
                                 >
                                     <IconLeft icon={faArrowRightToBracket} fixedWidth /> Join
+                                </Button>
+                            )}
+                            {couldJoin && (
+                                <Button as={UnstyledLink} to="/osuauth/login">
+                                    <IconLeft icon={faArrowRightToBracket} fixedWidth /> Login to
+                                    join
                                 </Button>
                             )}
                             {canLeave && (

--- a/src/Osuchan/Minigames/LobbyScreen.tsx
+++ b/src/Osuchan/Minigames/LobbyScreen.tsx
@@ -418,6 +418,7 @@ const LobbyScreen = observer((props: LobbyScreenProps) => {
     const currentGame = useCurrentGame();
     const isInOtherGame = currentGame !== null && currentGame.id !== minigame.id;
     const canJoin =
+        meStore.isAuthenticated &&
         playerTeamId === null &&
         !isInOtherGame &&
         (minigame.status === MinigameStatus.Lobby ||

--- a/src/Osuchan/Minigames/MinigameList.tsx
+++ b/src/Osuchan/Minigames/MinigameList.tsx
@@ -232,7 +232,7 @@ const LobbyRow = (props: LobbyRowProps) => {
                             <IconLeft icon={faEye} fixedWidth /> Spectate
                         </Button>
                     </UnstyledLink>
-                    {isJoinable && store.meStore.isAuthenticated && (
+                    {isJoinable && store.meStore.isAuthenticated ? (
                         <div onClick={(e) => e.stopPropagation()}>
                             <Button
                                 isLoading={
@@ -243,7 +243,11 @@ const LobbyRow = (props: LobbyRowProps) => {
                                 <IconLeft icon={faArrowRightToBracket} fixedWidth /> Join
                             </Button>
                         </div>
-                    )}
+                    ) : isJoinable && !store.meStore.isAuthenticated ? (
+                        <Button as={UnstyledLink} to="/osuauth/login">
+                            <IconLeft icon={faArrowRightToBracket} fixedWidth /> Login to join
+                        </Button>
+                    ) : null}
                 </ButtonRow>
             </LobbyActions>
         </Row>
@@ -299,9 +303,13 @@ const MinigameList = observer(() => {
                             Minigames
                             <BetaBadge>Closed beta for COE 2026</BetaBadge>
                         </SurfaceTitle>
-                        {meStore.isAuthenticated && (
+                        {meStore.isAuthenticated ? (
                             <Button action={() => setCreateModalOpen(true)}>
                                 <IconLeft icon={faPlus} fixedWidth /> Create Lobby
+                            </Button>
+                        ) : (
+                            <Button as={UnstyledLink} to="/osuauth/login">
+                                <IconLeft icon={faPlus} fixedWidth /> Login to create a lobby
                             </Button>
                         )}
                         <Button as={UnstyledLink} to="/minigames/history">

--- a/src/Osuchan/Minigames/MinigameList.tsx
+++ b/src/Osuchan/Minigames/MinigameList.tsx
@@ -232,10 +232,9 @@ const LobbyRow = (props: LobbyRowProps) => {
                             <IconLeft icon={faEye} fixedWidth /> Spectate
                         </Button>
                     </UnstyledLink>
-                    {isJoinable && (
+                    {isJoinable && store.meStore.isAuthenticated && (
                         <div onClick={(e) => e.stopPropagation()}>
                             <Button
-                                disabled={!store.meStore.isAuthenticated}
                                 isLoading={
                                     joinMutation.isPending && joinMutation.variables === minigame.id
                                 }
@@ -300,12 +299,11 @@ const MinigameList = observer(() => {
                             Minigames
                             <BetaBadge>Closed beta for COE 2026</BetaBadge>
                         </SurfaceTitle>
-                        <Button
-                            action={() => setCreateModalOpen(true)}
-                            disabled={!meStore.isAuthenticated}
-                        >
-                            <IconLeft icon={faPlus} fixedWidth /> Create Lobby
-                        </Button>
+                        {meStore.isAuthenticated && (
+                            <Button action={() => setCreateModalOpen(true)}>
+                                <IconLeft icon={faPlus} fixedWidth /> Create Lobby
+                            </Button>
+                        )}
                         <Button as={UnstyledLink} to="/minigames/history">
                             <IconLeft icon={faClockRotateLeft} fixedWidth /> History
                         </Button>

--- a/src/components/forms/ScoreFilterForm.tsx
+++ b/src/components/forms/ScoreFilterForm.tsx
@@ -187,33 +187,37 @@ export const ScoreFilterForm = observer((props: ScoreFilterFormProps) => {
                     onChange={(e) => setPresetName(e.currentTarget.value)}
                 />
             </FormControl>
-            <SaveNewButton
-                isLoading={meStore.isCreatingScoreFilterPreset}
-                $positive
-                type="button"
-                action={handleSavePreset}
-            >
-                Save New Preset
-            </SaveNewButton>
-            {preset !== null && (
+            {meStore.isAuthenticated && (
                 <>
-                    <SaveButton
-                        isLoading={meStore.isUpdatingScoreFilterPreset}
+                    <SaveNewButton
+                        isLoading={meStore.isCreatingScoreFilterPreset}
                         $positive
                         type="button"
-                        action={handleUpdatePreset}
+                        action={handleSavePreset}
                     >
-                        Save Preset
-                    </SaveButton>
-                    <DeleteButton
-                        isLoading={meStore.isDeletingScoreFilterPreset}
-                        $negative
-                        type="button"
-                        action={handleDeletePreset}
-                        confirmationMessage="Are you sure you want to delete this preset?"
-                    >
-                        Delete Preset
-                    </DeleteButton>
+                        Save New Preset
+                    </SaveNewButton>
+                    {preset !== null && (
+                        <>
+                            <SaveButton
+                                isLoading={meStore.isUpdatingScoreFilterPreset}
+                                $positive
+                                type="button"
+                                action={handleUpdatePreset}
+                            >
+                                Save Preset
+                            </SaveButton>
+                            <DeleteButton
+                                isLoading={meStore.isDeletingScoreFilterPreset}
+                                $negative
+                                type="button"
+                                action={handleDeletePreset}
+                                confirmationMessage="Are you sure you want to delete this preset?"
+                            >
+                                Delete Preset
+                            </DeleteButton>
+                        </>
+                    )}
                 </>
             )}
 

--- a/src/components/forms/ScoreFilterForm.tsx
+++ b/src/components/forms/ScoreFilterForm.tsx
@@ -187,7 +187,7 @@ export const ScoreFilterForm = observer((props: ScoreFilterFormProps) => {
                     onChange={(e) => setPresetName(e.currentTarget.value)}
                 />
             </FormControl>
-            {meStore.isAuthenticated && (
+            {meStore.isAuthenticated ? (
                 <>
                     <SaveNewButton
                         isLoading={meStore.isCreatingScoreFilterPreset}
@@ -219,6 +219,10 @@ export const ScoreFilterForm = observer((props: ScoreFilterFormProps) => {
                         </>
                     )}
                 </>
+            ) : (
+                <FormControl>
+                    <a href="/osuauth/login">Login to save score filter presets</a>
+                </FormControl>
             )}
 
             {/* Beatmap status */}


### PR DESCRIPTION
## Why?

Turns out if you never test as un-authed, you miss some obvious things.

## Changes

- Add auth checks to prevent rendering buttons for unauthed users
